### PR TITLE
Enable i386 build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ parts:
     source-type: tar
     source: 
       - on amd64: https://dl.pstmn.io/download/latest/linux64
-      - on i386: fail
+      - on i386: https://dl.pstmn.io/download/latest/linux32
       - on armhf: fail
       - on arm64: fail
     build-packages:


### PR DESCRIPTION
Shouldn't matter too much, but Postman provide it so I see no reason not to add this. Tested in a 32bit Ubuntu 16.04.5 VM and it worked fine.