### PR TITLE
Add architectures stanza

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,10 @@ description: |
 
 grade: stable
 confinement: strict
+
+architectures:
+  - build-on: amd64
+  - build-on: i386
  
 parts:
   postman:
@@ -16,8 +20,6 @@ parts:
     source: 
       - on amd64: https://dl.pstmn.io/download/latest/linux64
       - on i386: https://dl.pstmn.io/download/latest/linux32
-      - on armhf: fail
-      - on arm64: fail
     build-packages:
      - jshon
     override-build: |


### PR DESCRIPTION
Adding the architectures stanza which means we don't waste time building on unsupported architectures. See [this thread](https://forum.snapcraft.io/t/architectures/4972) for more details.