### PR TITLE
Remove iffy files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,6 +29,7 @@ parts:
     override-build: |
      mkdir $SNAPCRAFT_PART_INSTALL/usr/share/Postman
      mv app/* $SNAPCRAFT_PART_INSTALL/usr/share/Postman
+     rm "$SNAPCRAFT_PART_INSTALL/usr/share/Postman/resources/app/node_modules/@postman-app/logger/node_modules/colors/lib/.colors.js.swp"
      VERSION=$(cat $SNAPCRAFT_PART_INSTALL/usr/share/Postman/resources/app/package.json | jshon -e version | sed 's/\"//g')
      echo $VERSION > $SNAPCRAFT_STAGE/version
     stage:


### PR DESCRIPTION
Store is rejecting builds due to "found potentially sensitive files in package: usr/share/Postman/resources/app/node_modules/@postman-app/logger/node_modules/colors/lib/.colors.js.swp lint-snap-v2_iffy_files ". So manually rm'ing that out during the build.